### PR TITLE
use an info.py file to allow integration with casa-distro/bv_maker

### DIFF
--- a/moving_averages/info.py
+++ b/moving_averages/info.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+version_major = 0
+version_minor = 0
+version_micro = 40
+version_extra = ''
+
+# Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
+__version__ = "%s.%s.%s%s" % (version_major,
+                              version_minor,
+                              version_micro,
+                              version_extra)
+CLASSIFIERS = [
+    "Programming Language :: Python",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent",
+]
+
+
+description = "Tools for the calculation of moving averages of 3D objects"
+
+# versions for dependencies
+SPHINX_MIN_VERSION = '1.0'
+
+# Main setup parameters
+NAME = 'moving_averages'
+PROJECT = 'point-cloud-pattern-mining'
+ORGANISATION = "neurospin"
+MAINTAINER = "nobody"
+MAINTAINER_EMAIL = "support@neurospin.info"
+DESCRIPTION = description
+URL = "https://github.com/neurospin/point-cloud-pattern-mining"
+DOWNLOAD_URL = "https://github.com/neurospin/point-cloud-pattern-mining"
+LICENSE = "CeCILL-B"
+AUTHOR = 'Marco Pascucci - NeuroSpin (CEA)'
+AUTHOR_EMAIL = 'marpas.paris@gmail.com'
+PLATFORMS = "OS Independent"
+PROVIDES = ["moving_averages"]
+REQUIRES = ['plotly==4.14.3', 'scipy>=0.22']
+EXTRA_REQUIRES = {
+    "doc": ["sphinx>=" + SPHINX_MIN_VERSION],
+}
+# from python 3.6, dictionary order is preserved during execution
+PYTHON_REQUIRES = '>=3.6'
+
+brainvisa_build_model = 'pure_python'
+

--- a/moving_averages/info.py
+++ b/moving_averages/info.py
@@ -35,13 +35,20 @@ LICENSE = "CeCILL-B"
 AUTHOR = 'Marco Pascucci - NeuroSpin (CEA)'
 AUTHOR_EMAIL = 'marpas.paris@gmail.com'
 PLATFORMS = "OS Independent"
-PROVIDES = ["moving_averages"]
+PROVIDES = ['moving_averages', 'moving_averages.distance',
+            'moving_averages.isomap']
 REQUIRES = ['plotly==4.14.3', 'scipy>=0.22']
 EXTRA_REQUIRES = {
     "doc": ["sphinx>=" + SPHINX_MIN_VERSION],
 }
 # from python 3.6, dictionary order is preserved during execution
 PYTHON_REQUIRES = '>=3.6'
+ENTRYPOINTS = {
+    'console_scripts': [
+        'mav_volume_to_points_cloud=moving_averages.cli.volume_to_points_cloud:main',
+        'mav_icp=moving_averages.cli.icp:main'
+        ],
+    }
 
 brainvisa_build_model = 'pure_python'
 

--- a/setup.py
+++ b/setup.py
@@ -3,29 +3,29 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(name='moving_averages',
-    # from python 3.6, dictionary order is preserved during execution
-    python_requires='>3.6',
+release_info = {}
+python_dir = os.path.dirname(__file__)
+with open(os.path.join(python_dir, "dico_toolbox", "info.py")) as f:
+    code = f.read()
+    exec(code, release_info)
 
-    version='0.0.40',
-    description='Tools for the calculation of moving averages of 3D objects',
-    author='Marco Pascucci - NeuroSpin (CEA)',
+setuptools.setup(
+    name=release_info['NAME'],
+    version=release_info['__version__'],
+    description=release_info['DESCRIPTION'],
+    author=release_info['AUTHOR'],
+    author_email=release_info['AUTHOR_EMAIL']
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author_email='marpas.paris@gmail.com',
-    url='',
+    url=release_info['URL'],
     packages=['moving_averages', 'moving_averages.distance', 'moving_averages.isomap'],
-    install_requires=['plotly==4.14.3', 'scipy>=0.22'],
+    install_requires=release_info["REQUIRES"],
+    classifiers=release_info["CLASSIFIERS"]
+    python_requires=release_info['PYTHON_REQUIRES'],
     entry_points = {
     'console_scripts': [
         'mav_volume_to_points_cloud=moving_averages.cli.volume_to_points_cloud:main',
         'mav_icp=moving_averages.cli.icp:main'
         ],
     },
-
-    classifiers=[
-        "Programming Language :: Python",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 release_info = {}
 python_dir = os.path.dirname(__file__)
-with open(os.path.join(python_dir, "dico_toolbox", "info.py")) as f:
+with open(os.path.join(python_dir, "moving_averages", "info.py")) as f:
     code = f.read()
     exec(code, release_info)
 
@@ -18,14 +18,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url=release_info['URL'],
-    packages=['moving_averages', 'moving_averages.distance', 'moving_averages.isomap'],
+    packages=release_info['PROVIDES'],
     install_requires=release_info["REQUIRES"],
     classifiers=release_info["CLASSIFIERS"]
     python_requires=release_info['PYTHON_REQUIRES'],
-    entry_points = {
-    'console_scripts': [
-        'mav_volume_to_points_cloud=moving_averages.cli.volume_to_points_cloud:main',
-        'mav_icp=moving_averages.cli.icp:main'
-        ],
-    },
+    entry_points = release_info['ENTRYPOINTS'],
 )


### PR DESCRIPTION
this is just a separation of what was in setup.py into 2 files, the
info.py file being read by bv_maker not only for setup. Moreover it
allows to get info at runtime (to get library version etc) when needed.